### PR TITLE
Make Facebook user fields configurable via custom Provider Store

### DIFF
--- a/src/IdentityServer.External.TokenExchange/Config/Providers.cs
+++ b/src/IdentityServer.External.TokenExchange/Config/Providers.cs
@@ -14,6 +14,7 @@ namespace IdentityServer.External.TokenExchange.Config
                 new ExternalTokenExchangeProvider
                 {
                     Id = 1,
+                    Fields = "id,email,name,gender,birthday",
                     Name = "Facebook",
                     UserInfoEndpoint = "https://graph.facebook.com/v2.8/me"
                 },

--- a/src/IdentityServer.External.TokenExchange/Models/ExternalTokenExchangeProvider.cs
+++ b/src/IdentityServer.External.TokenExchange/Models/ExternalTokenExchangeProvider.cs
@@ -7,6 +7,7 @@ namespace IdentityServer.External.TokenExchange.Models
     public class ExternalTokenExchangeProvider
     {
         public int Id { get; set; }
+        public string Fields { get; set; }
         public string Name { get; set; }
         public string UserInfoEndpoint { get; set; }
     }

--- a/src/IdentityServer.External.TokenExchange/Providers/FacebookAuthProvider.cs
+++ b/src/IdentityServer.External.TokenExchange/Providers/FacebookAuthProvider.cs
@@ -33,7 +33,7 @@ namespace IdentityServer.External.TokenExchange.Providers
 
             var request = new Dictionary<string, string>
             {
-                {"fields", "id,email,name,gender,birthday"},
+                {"fields", provider.Fields},
                 {"access_token", accessToken}
             };
             var result = await _client.GetAsync(provider.UserInfoEndpoint + QueryBuilder.GetQuery(request, TokenExchangeProviders.Facebook));


### PR DESCRIPTION
Currently, the default Facebook fields "gender" and "birthday" require Facebook Review Approval. Since this may not be necessary for some apps, let's make this configurable via a custom Provider Store.

Example:

**MyCustomProviders.cs**

```
public static class MyCustomProviders
{
    public static IEnumerable<ExternalTokenExchangeProvider> GetProviders()
    {
        return new List<ExternalTokenExchangeProvider>
        {
            new ExternalTokenExchangeProvider
            {
                Id = 1,
                Fields = "id,email,name",
                Name = "Facebook",
                UserInfoEndpoint = "https://graph.facebook.com/v2.8/me"
            }
        };
    }
}
```

**MyCustomProviderStore.cs**
```
public class MyCustomProviderStore : DefaultTokenExchangeProviderStore
{
    public MyCustomProviderStore () : base(MyCustomProviders.GetProviders()) {}
}
```

**Startup.cs**
```
public void ConfigureServices(IServiceCollection services)
{
    services.buildIdentityServer()
        .AddCustomTokenExchangeProviderStore<MyCustomProviderStore>();
}
```